### PR TITLE
Implement connecting to Janus gateway

### DIFF
--- a/new/brewblox_service/announcer.py
+++ b/new/brewblox_service/announcer.py
@@ -1,0 +1,79 @@
+"""
+Announces to ecosystem managers that plugin services are available.
+"""
+
+import logging
+from typing import Type
+from urllib.parse import urljoin
+
+import requests
+from flask import Flask
+from requests.exceptions import ConnectionError
+
+from brewblox_service import rest
+
+LOGGER = logging.getLogger(__name__)
+CREDENTIALS = {
+    'username': 'admin',
+    'password': 'admin'
+}
+
+
+def create_proxy_spec(app: Type[Flask]) -> dict:
+    port = app.config['port']
+    prefix = app.config['prefix']
+    identifier = app.config['service_name']
+    url = urljoin(f'http://localhost:{port}', prefix)
+
+    spec = {
+        'name': identifier,
+        'active': True,
+        'proxy': {
+            # Strips 'listen_path'
+            'strip_path': True,
+            # Appends everything past 'listen_path'
+            'append_path': True,
+            # Alls calls that match this are forwarded
+            'listen_path': f'/{identifier}/*',
+            # HTTP methods of these types are forwarded
+            'methods': rest.all_methods(),
+            # Addresses to which requests are forwarded
+            'upstreams': {
+                'balancing': 'roundrobin',
+                'targets': [{'target': url}]
+            }
+        },
+        'health_check': {
+            'url': url + '/_service/status'
+        }
+    }
+
+    return spec
+
+
+def auth_header(gateway: str) -> dict:
+    res = requests.post(urljoin(gateway, 'login'), json=CREDENTIALS)
+    headers = {'authorization': 'Bearer ' + res.json()['access_token']}
+    return headers
+
+
+def announce(app: Type[Flask]):
+    gateway = app.config['gateway']
+    service_name = app.config['service_name']
+
+    try:
+        url = urljoin(gateway, 'apis')
+        spec = create_proxy_spec(app)
+        headers = auth_header(gateway)
+
+        LOGGER.debug(f'announcing spec: {spec}')
+
+        # try to unregister previous instance of API
+        delete_url = urljoin(gateway, f'apis/{service_name}')
+        requests.delete(delete_url, headers=headers)
+
+        # register service
+        requests.post(url, headers=headers, json=spec)
+
+    except ConnectionError as ex:
+        LOGGER.warn(f'failed to announce to gateway: {str(ex)}')

--- a/new/brewblox_service/plugger.py
+++ b/new/brewblox_service/plugger.py
@@ -13,7 +13,14 @@ LOGGER = logging.getLogger(__name__)
 
 class PluginsView(MethodView):
     def get(self):
-        return jsonify([p.identifier for p in get_enabled_plugins()])
+        plugins = []
+        try:
+            plugins = [p.identifier for p in get_enabled_plugins()]
+        except AttributeError as ex:
+            # get_enabled_plugins() throws if no plugins were found.
+            # we can ignore this.
+            pass
+        return jsonify(plugins)
 
 
 class PluginDetailsView(MethodView):
@@ -26,8 +33,8 @@ class PluginDetailsView(MethodView):
 
 
 def init_app(app: Type[Flask]):
-    rest.register(app, '/system/plugins', PluginsView)
-    rest.register(app, '/system/plugins/<id>', PluginDetailsView)
+    rest.register(app, '/_service/plugins', PluginsView)
+    rest.register(app, '/_service/plugins/<id>', PluginDetailsView)
 
     plugin_dir = app.config['plugin_dir']
 

--- a/new/brewblox_service/plugins/simulator/__init__.py
+++ b/new/brewblox_service/plugins/simulator/__init__.py
@@ -46,9 +46,10 @@ class SimulatorPlugin(Plugin):
 
     def setup(self):
         """Performs setup steps - this is done inside the app context"""
-        rest.register(current_app, '/simulator/config', ConfigView, plugin=self)
-        rest.register(current_app, '/simulator/values/<string:id>', FilteredValuesView, plugin=self)
-        rest.register(current_app, '/simulator/values/', ValuesView, plugin=self)
+        rest.register(current_app, '/config', ConfigView, plugin=self)
+        rest.register(current_app, '/values/<string:id>',
+                      FilteredValuesView, plugin=self)
+        rest.register(current_app, '/values/', ValuesView, plugin=self)
 
     @property
     def config(self):

--- a/new/brewblox_service/rest.py
+++ b/new/brewblox_service/rest.py
@@ -2,7 +2,7 @@ import logging
 import re
 from typing import Type
 
-from flask import Flask, request
+from flask import Flask, request, jsonify
 from flask.views import View
 
 LOGGER = logging.getLogger(__name__)
@@ -20,6 +20,27 @@ class Shutdown(View):
     def dispatch_request(self):
         self.shutdown_server()
         return 'Shutting down...'
+
+
+class HealthCheck(View):
+    methods = ['GET']
+
+    def dispatch_request(self):
+        return jsonify(status='ok')
+
+
+def all_methods():
+    return [
+        'GET',
+        'HEAD',
+        'POST',
+        'PUT',
+        'DELETE',
+        'CONNECT',
+        'OPTIONS',
+        'TRACE',
+        'PATCH'
+    ]
 
 
 def register(app: Type[Flask], path: str, resource: Type[View], **params):
@@ -45,6 +66,7 @@ def create_app(config: dict) -> Type[Flask]:
     app = Flask(config['name'])
     app.config.update(config)
 
-    register(app, '/shutdown', Shutdown)
+    register(app, '/_service/shutdown', Shutdown)
+    register(app, '/_service/status', HealthCheck)
 
     return app

--- a/new/requirements.txt
+++ b/new/requirements.txt
@@ -4,3 +4,4 @@ flask-apispec
 flask-plugins
 pprint
 dpath
+requests

--- a/new/setup.py
+++ b/new/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='brewblox-service',
-    version='0.1',
+    version='0.2',
     long_description=open('README.md').read(),
     url='https://github.com/BrewBlox/brewblox-service',
     author='BrewPi',

--- a/new/setup.py
+++ b/new/setup.py
@@ -25,6 +25,7 @@ setup(
         'flask-plugins',
         'pprint',
         'dpath',
+        'requests',
     ],
     extras_require={'dev': ['tox']},
     entry_points={

--- a/new/test/conftest.py
+++ b/new/test/conftest.py
@@ -23,8 +23,11 @@ def log_enabled():
 def app_config() -> dict:
     return {
         'name': 'test_app',
+        'service_name': 'test_name',
         'prefix': '',
         'plugin_dir': 'plugins',
+        'port': 1234,
+        'gateway': 'http://gatewayaddr:1234'
     }
 
 

--- a/new/test/test_announcer.py
+++ b/new/test/test_announcer.py
@@ -1,0 +1,67 @@
+"""
+Tests brewblox_service.announcer.py
+"""
+
+from brewblox_service import announcer, rest
+
+TESTED = 'brewblox_service.announcer'
+
+
+def test_create_proxy_spec(app):
+    spec = announcer.create_proxy_spec(app)
+
+    assert spec == {
+        'name': 'test_name',
+        'active': True,
+        'proxy': {
+            'strip_path': True,
+            'append_path': True,
+            'listen_path': '/test_name/*',
+            'methods': rest.all_methods(),
+            'upstreams': {
+                'balancing': 'roundrobin',
+                'targets': [{'target': 'http://localhost:1234'}]
+            }
+        },
+        'health_check': {
+            'url': 'http://localhost:1234/_service/status'
+        }
+    }
+
+
+def test_auth_header(mocker):
+    req_mock = mocker.patch(TESTED + '.requests')
+    req_mock.post.return_value.json.return_value = {
+        'access_token': 'tokkie'
+    }
+
+    res = announcer.auth_header('http://gateway')
+
+    assert res == {'authorization': 'Bearer tokkie'}
+    req_mock.post.assert_called_once_with(
+        'http://gateway/login',
+        json={
+            'username': 'admin',
+            'password': 'admin'
+        })
+
+
+def test_announce_err(mocker, app):
+    log_mock = mocker.patch(TESTED + '.LOGGER')
+    announcer.announce(app)
+    assert log_mock.warn.call_count == 1
+
+
+def test_announce(mocker, app):
+    headers = {'auth': 'val'}
+    spec = announcer.create_proxy_spec(app)
+
+    req_mock = mocker.patch(TESTED + '.requests')
+    mocker.patch(TESTED + '.auth_header').return_value = headers
+
+    announcer.announce(app)
+
+    req_mock.delete.assert_called_once_with(
+        'http://gatewayaddr:1234/apis/test_name', headers=headers)
+    req_mock.post.assert_called_once_with(
+        'http://gatewayaddr:1234/apis', headers=headers, json=spec)

--- a/new/test/test_main.py
+++ b/new/test/test_main.py
@@ -5,6 +5,9 @@ Test functions for brewblox_service.__main__
 from brewblox_service import __main__ as main
 
 
+TESTED = 'brewblox_service.__main__'
+
+
 def test_get_args():
     # test defaults
     args = main.get_args([])
@@ -35,8 +38,8 @@ def test_get_args():
 
 
 def test_init_logging(mocker):
-    log_mock = mocker.patch('brewblox_service.__main__.logging')
-    handler = mocker.patch('brewblox_service.__main__.TimedRotatingFileHandler').return_value
+    log_mock = mocker.patch(TESTED + '.logging')
+    handler = mocker.patch(TESTED + '.TimedRotatingFileHandler').return_value
 
     args = main.get_args([])
     main.init_logging(args)
@@ -56,12 +59,14 @@ def test_furnish_app(app):
 
 
 def test_main(mocker):
-    log_mock = mocker.patch('brewblox_service.__main__.init_logging')
-    app_mock = mocker.patch('brewblox_service.__main__.rest.create_app').return_value
-    furnish_mock = mocker.patch('brewblox_service.__main__.furnish_app')
+    log_mock = mocker.patch(TESTED + '.init_logging')
+    app_mock = mocker.patch(TESTED + '.rest.create_app').return_value
+    furnish_mock = mocker.patch(TESTED + '.furnish_app')
+    announce_mock = mocker.patch(TESTED + '.announcer.announce')
 
     main.main([])
 
     assert log_mock.call_count == 1
     assert furnish_mock.call_count == 1
+    assert announce_mock.call_count == 1
     assert app_mock

--- a/new/test/test_plugger.py
+++ b/new/test/test_plugger.py
@@ -12,8 +12,8 @@ def test_init(mocker, app):
     plugger.init_app(app)
 
     rest_mock.register.assert_has_calls([
-        call(app, '/system/plugins', plugger.PluginsView),
-        call(app, '/system/plugins/<id>', plugger.PluginDetailsView)
+        call(app, '/_service/plugins', plugger.PluginsView),
+        call(app, '/_service/plugins/<id>', plugger.PluginDetailsView)
     ])
 
 
@@ -21,30 +21,36 @@ def test_endpoints(app, client):
     plugger.init_app(app)
 
     # enumerate all plugins
-    res = client.get('/system/plugins')
+    res = client.get('/_service/plugins')
     assert res.status_code == 200
     assert res.json == ['simulator']
 
     # no plugin found with ID '1'
-    assert client.get('/system/plugins/1').status_code == 400
+    assert client.get('/_service/plugins/1').status_code == 400
 
     # simulator can be found
-    res = client.get('/system/plugins/simulator')
+    res = client.get('/_service/plugins/simulator')
     assert res.status_code == 200
     assert res.json
     assert res.json['identifier'] == 'simulator'
     assert res.json['name'] == 'BrewBlox Block Simulator'
 
 
-def test_no_plugin_dir(mocker, app):
+def test_no_plugin_dir(mocker, app, client):
     log_mock = mocker.patch('brewblox_service.plugger.LOGGER')
     app.config['plugin_dir'] = 'narnia'
     plugger.init_app(app)
     assert log_mock.warn.call_count > 0
 
+    # getting all plugins shouldn't fail
+    assert client.get('/_service/plugins').status_code == 200
 
-def test_invalid_app(mocker, app):
+
+def test_invalid_app(mocker, app, client):
     mgr_mock = mocker.patch('brewblox_service.plugger.PluginManager')
     app.name = 'absolute nonsense'
     plugger.init_app(app)
     assert mgr_mock.call_count == 0
+
+    # getting all plugins shouldn't fail
+    assert client.get('/_service/plugins').status_code == 200

--- a/new/test/test_rest.py
+++ b/new/test/test_rest.py
@@ -32,11 +32,24 @@ def test_register():
 
 
 def test_shutdown(mocker, app, client):
-    assert client.post('/shutdown').status_code == 500
+    endpoint = '/_service/shutdown'
+    assert client.post(endpoint).status_code == 500
 
     shutdown_mock = Mock()
     request_mock = mocker.patch('brewblox_service.rest.request')
     request_mock.environ.get.return_value = shutdown_mock
 
-    assert client.post('/shutdown').status_code == 200
+    assert client.post(endpoint).status_code == 200
     assert shutdown_mock.call_count == 1
+
+
+def test_healthcheck(app, client):
+    endpoint = '/_service/status'
+
+    res = client.get(endpoint)
+    assert res.status_code == 200
+    assert res.json == {'status': 'ok'}
+
+
+def test_all_methods():
+    assert 'GET' in rest.all_methods()

--- a/new/test/test_simulator.py
+++ b/new/test/test_simulator.py
@@ -45,35 +45,35 @@ def plugged(app):
 
 
 def test_config(client, plugged, sim_config):
-    res = client.get('/simulator/config')
+    res = client.get('/config')
     assert res.status_code == 200
     assert res.json == {}
 
     # no args supplied
-    assert client.post('/simulator/config').status_code == 500
+    assert client.post('/config').status_code == 500
 
     # actual config
-    assert client.post('/simulator/config', json=sim_config).status_code == 200
+    assert client.post('/config', json=sim_config).status_code == 200
 
     # now retrieve
-    res = client.get('/simulator/config')
+    res = client.get('/config')
     assert res.status_code == 200
     assert res.json == sim_config
 
 
 def test_values(client, plugged, sim_config):
-    assert client.post('/simulator/config', json=sim_config).status_code == 200
+    assert client.post('/config', json=sim_config).status_code == 200
 
-    res = client.get('/simulator/values')
+    res = client.get('/values')
     assert res.status_code == 200
     assert len(res.json) == 2
     assert res.json[0]['identifier'] in ['1.2.3', '2.3.4']
     print(res.json)
 
-    res = client.get('/simulator/values/1.2.3')
+    res = client.get('/values/1.2.3')
     assert res.status_code == 200
     assert res.json['identifier'] == '1.2.3'
 
-    res = client.get('/simulator/values/oilwell')
+    res = client.get('/values/oilwell')
     assert res.status_code == 200
     assert res.json == dict()


### PR DESCRIPTION
On service startup, announces itself to the gateway /apis endpoint. (default: `http://localhost:8081/apis`)

By default it indicates that `/<service>/*` requests should be forwarded. This can be changed with the `--name` commandline switch.

Default brewblox_service endpoints were moved to `/_service/`. They are now:
* /_service/shutdown
* /_service/status
* /_service/plugins
* /_service/plugins/[id]
