### PR TITLE
implement workaround to avoid endlessly blocking IO

### DIFF
--- a/test/test_events.py
+++ b/test/test_events.py
@@ -47,6 +47,7 @@ def set_connect_func(mocker, closed: bool):
 async def app(app, mocker, loop):
     """App with events enabled"""
     set_connect_func(mocker, closed=False)
+    mocker.patch(TESTED + '._wait_host_resolved', CoroutineMock())
 
     events.setup(app)
     return app


### PR DESCRIPTION
See https://github.com/mosquito/aio-pika/issues/124 for issue description.

This implements a rather brute-force solution to at least keep the service responsive. App on_startup() returns after scheduling start().

`start()` first loops async over `loop.getaddrinfo()` until it doesn't throw an error, before it attempts the actual `aio_pika.robust_connection()` call.

Note: this only works if the eventbus host is slow in coming online (or doesn't come online at all). If the eventbus comes online, and then exits, this service will be frozen solid. 