### PR TITLE
Service feature tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ service.run(app)
 
 Many service features are application-scoped. Their lifecycle should span multiple requests, either because they are not request-driven, or because they manage asynchronous I/O operations (such as listening to AMQP messages).
 
-The `ServiceFeature` class offers an abstract base class for this behavior. Implementing classes should define `start(app)` and `close(app)` functions, and those will be automatically called when the application starts up and shuts down.
+The `ServiceFeature` class offers an abstract base class for this behavior. Implementing classes should define `startup(app)` and `shutdown(app)` functions, and those will be automatically called when the application starts up and shuts down.
 
-Both `start()` and `close()` are called in an async context, making them the async counterparts of `__init__()` and `__del__()` functions.
+Both `startup()` and `shutdown()` are called in an async context, making them the async counterparts of `__init__()` and `__del__()` functions.
 
 Features must be constructed after the app is created, but before it starts running. (`service.create_app()` and `service.run(app)`)
 

--- a/brewblox_service/events.py
+++ b/brewblox_service/events.py
@@ -324,7 +324,7 @@ class EventPublisher(features.ServiceFeature):
         try:
             await self._protocol.ensure_open()
         except aioamqp.exceptions.AioamqpException:
-            await self.close()
+            await self.shutdown()
             raise
 
     async def publish(self,

--- a/brewblox_service/events.py
+++ b/brewblox_service/events.py
@@ -137,7 +137,7 @@ class EventListener(features.ServiceFeature):
     def __str__(self):
         return f'<{type(self).__name__} {self._host}>'
 
-    async def start(self, app: web.Application):
+    async def startup(self, app: web.Application):
         # Initialize the async queue now we know which loop we're using
         self._loop = app.loop
         self._pending = asyncio.Queue(loop=self._loop)
@@ -150,7 +150,7 @@ class EventListener(features.ServiceFeature):
 
         self._lazy_listen()
 
-    async def close(self, *args):
+    async def shutdown(self, *_):
         LOGGER.info(f'Closing {self}')
 
         try:
@@ -292,7 +292,7 @@ class EventPublisher(features.ServiceFeature):
     def __str__(self):
         return f'<{type(self).__name__} {self._host}>'
 
-    async def start(self, app: web.Application):
+    async def startup(self, app: web.Application):
         self._loop = app.loop
 
     def _reset(self):
@@ -300,7 +300,7 @@ class EventPublisher(features.ServiceFeature):
         self._protocol: aioamqp.AmqpProtocol = None
         self._channel: aioamqp.channel.Channel = None
 
-    async def close(self, *args):
+    async def shutdown(self, *args):
         LOGGER.info(f'Closing {self}')
 
         try:

--- a/brewblox_service/events.py
+++ b/brewblox_service/events.py
@@ -300,7 +300,7 @@ class EventPublisher(features.ServiceFeature):
         self._protocol: aioamqp.AmqpProtocol = None
         self._channel: aioamqp.channel.Channel = None
 
-    async def shutdown(self, *args):
+    async def shutdown(self, *_):
         LOGGER.info(f'Closing {self}')
 
         try:

--- a/brewblox_service/features.py
+++ b/brewblox_service/features.py
@@ -64,10 +64,10 @@ class ServiceFeature(ABC):
             app.on_cleanup.append(self.shutdown)
 
     async def startup(self, app: web.Application):
-        await self.start(app)
+        await self.start(app)  # pragma: no cover
 
     async def shutdown(self, app: web.Application):
-        await self.close(app)
+        await self.close(app)  # pragma: no cover
 
     # left in for backwards compatibility
     async def start(self, app: web.Application):

--- a/brewblox_service/features.py
+++ b/brewblox_service/features.py
@@ -2,6 +2,7 @@
 Registers and gets features added to Aiohttp by brewblox services.
 """
 
+import warnings
 from abc import ABC
 from typing import Type
 
@@ -120,8 +121,8 @@ class ServiceFeature(ABC):
             callable(getattr(self, 'start', None)),
             callable(getattr(self, 'close', None))
         ]):
-            raise DeprecationWarning(
-                'start(app) and close(app) functions are deprecated. Use startup(app) and shutdown(app) instead')
+            message = 'start(app) and close(app) functions are deprecated. Use startup(app) and shutdown(app) instead'
+            warnings.warn(message)
 
         if app:
             app.on_startup.append(self.startup)

--- a/brewblox_service/features.py
+++ b/brewblox_service/features.py
@@ -57,22 +57,98 @@ def get(app: web.Application, feature_type: Type['ServiceFeature']=None, name: s
 
 
 class ServiceFeature(ABC):
+    """Base class for long-lived Aiohttp handler classes.
+
+    For classes with async functionality,
+    the (synchronous) `__init__()` and `__del__()` functions may not be sufficient.
+    Aiohttp offers comparable init/deinit hooks, but inside the context of a running event loop.
+
+    ServiceFeature registers the `self.startup(self, app)` and `self.shutdown(self, app)` as lifecycle callbacks.
+    They will be called by Aiohttp at the appropriate moment.
+    By overriding these functions, subclasses can perform initialization/deinitialization that requires an event loop.
+
+    Note: Aiohttp will not accept registration of new callbacks after it started running.
+    Automatic lifecycle management can be disabled by passing a None value to `ServiceFeature.__init__(self, app)`.
+    In this case, `startup()` and `shutdown()` will need to be called manually.
+
+    Example class:
+
+        import asyncio
+        from aiohttp import web
+        from brewblox_service import service
+        from brewblox_service.features import ServiceFeature
+
+        class MyFeature(ServiceFeature):
+
+            def __init__(self, app: web.Application):
+                super().__init__(app)
+                self._task: asyncio.Task = None
+
+            async def startup(self, app: web.Application):
+                # Schedule a long-running background task
+                self._task = app.loop.create_task(self._hello())
+
+            async def shutdown(self, app: web.Application):
+                # Orderly cancel the background task
+                try:
+                    self._task.cancel()
+                    await self._task
+                except Exception:
+                    pass
+
+            async def _hello(self):
+                while True:
+                    await asyncio.sleep(5)
+                    print('still here!')
+
+    Example use:
+
+        app = service.create_app(default_name='example')
+
+        greeter = MyFeature(app)
+
+        service.furnish(app)
+        service.run(app)
+        # greeter.startup(app) is called now
+
+        # Press Ctrl+C to quit
+        # greeter.shutdown(app) will be called
+    """
 
     def __init__(self, app: web.Application):
+        if any([
+            callable(getattr(self, 'start', None)),
+            callable(getattr(self, 'close', None))
+        ]):
+            raise DeprecationWarning(
+                'start(app) and close(app) functions are deprecated. Use startup(app) and shutdown(app) instead')
+
         if app:
             app.on_startup.append(self.startup)
             app.on_cleanup.append(self.shutdown)
 
     async def startup(self, app: web.Application):
-        await self.start(app)  # pragma: no cover
+        """Lifecycle hook for initializing the feature in an async context.
+
+        Subclasses are expected to override this function.
+
+        If `app` in the ServiceFeature.__init__(app) call was not None,
+        startup() will be called when Aiohttp starts running.
+        """
+
+        # Attempt to fall back on old function name
+        if callable(getattr(self, 'start', None)):
+            await self.start(app)
 
     async def shutdown(self, app: web.Application):
-        await self.close(app)  # pragma: no cover
+        """Lifecycle hook for shutting down the feature before the event loop is closed.
 
-    # left in for backwards compatibility
-    async def start(self, app: web.Application):
-        pass  # pragma: no cover
+        Subclasses are expected to override this function.
 
-    # left in for backwards compatibility
-    async def close(self, app: web.Application):
-        pass  # pragma: no cover
+        If `app` in the ServiceFeature.__init__(app) call was not None,
+        shutdown() will be called when Aiohttp is closing, but before the event loop is closed.
+        """
+
+        # Attempt to fall back on old function name
+        if callable(getattr(self, 'close', None)):
+            await self.close(app)

--- a/brewblox_service/features.py
+++ b/brewblox_service/features.py
@@ -2,7 +2,7 @@
 Registers and gets features added to Aiohttp by brewblox services.
 """
 
-from abc import ABC, abstractmethod
+from abc import ABC
 from typing import Type
 
 from aiohttp import web
@@ -58,15 +58,21 @@ def get(app: web.Application, feature_type: Type['ServiceFeature']=None, name: s
 
 class ServiceFeature(ABC):
 
-    def __init__(self, app: web.Application=None):
+    def __init__(self, app: web.Application):
         if app:
-            app.on_startup.append(self.start)
-            app.on_cleanup.append(self.close)
+            app.on_startup.append(self.startup)
+            app.on_cleanup.append(self.shutdown)
 
-    @abstractmethod
+    async def startup(self, app: web.Application):
+        await self.start(app)
+
+    async def shutdown(self, app: web.Application):
+        await self.close(app)
+
+    # left in for backwards compatibility
     async def start(self, app: web.Application):
         pass  # pragma: no cover
 
-    @abstractmethod
+    # left in for backwards compatibility
     async def close(self, app: web.Application):
         pass  # pragma: no cover

--- a/brewblox_service/service.py
+++ b/brewblox_service/service.py
@@ -33,6 +33,7 @@ from typing import List
 import aiohttp_cors
 import aiohttp_swagger
 from aiohttp import web
+from brewblox_service import features
 
 LOGGER = logging.getLogger(__name__)
 routes = web.RouteTableDef()
@@ -206,7 +207,10 @@ def furnish(app: web.Application):
                                   contact='development@brewpi.com')
 
     for route in app.router.routes():
-        LOGGER.info(f'Registered [{route.method}] {route.resource}')
+        LOGGER.info(f'Endpoint [{route.method}] {route.resource}')
+
+    for name, impl in app.get(features.FEATURES_KEY, {}).items():
+        LOGGER.info(f'Feature [{name}] {impl}')
 
 
 def run(app: web.Application):

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -108,7 +108,7 @@ async def test_offline_listener(app, mocker):
     assert sub in listener._pending_pre_async
 
     # Can safely be called, but will be a no-op at this time
-    await listener.close()
+    await listener.shutdown()
 
 
 async def test_online_listener(app, client, mocker):
@@ -121,10 +121,10 @@ async def test_online_listener(app, client, mocker):
     sub = listener.subscribe('exchange', 'routing')
 
     # No-op, listener is not yet started
-    await listener.close()
+    await listener.shutdown()
 
     assert sub in listener._pending_pre_async
-    await listener.start(app)
+    await listener.startup(app)
     assert listener._pending_pre_async is None
 
     pending_subs = listener._pending.qsize()
@@ -133,8 +133,8 @@ async def test_online_listener(app, client, mocker):
     assert listener._pending.qsize() == pending_subs + 1
 
     # Safe for repeated calls
-    await listener.close()
-    await listener.close()
+    await listener.shutdown()
+    await listener.shutdown()
 
 
 async def test_offline_publisher(app):
@@ -148,7 +148,7 @@ async def test_online_publisher(app, client, mocker):
         events.EventPublisher(app)
 
     publisher = events.EventPublisher()
-    await publisher.start(app)
+    await publisher.startup(app)
 
     await publisher.publish('exchange', 'key', message=dict(key='val'))
     await publisher.publish('exchange', 'key', message=dict(key='val'))
@@ -224,7 +224,7 @@ async def test_listener_exceptions(app, client, protocol_mock, channel_mock, tra
     assert not listener._task.done()
 
     # Should be closed every time it was opened
-    await listener.close()
+    await listener.shutdown()
     assert protocol_mock.close.call_count == mocked_connect.call_count
     assert transport_mock.close.call_count == mocked_connect.call_count
 

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -103,9 +103,6 @@ async def test_offline_listener(app, mocker):
     # Expected behaviour is for the listener to add functions to the app hooks
     listener = events.EventListener(app)
 
-    assert listener.start in app.on_startup
-    assert listener.close in app.on_cleanup
-
     # Subscriptions will not be declared yet - they're waiting for startup
     sub = listener.subscribe('exchange', 'routing')
     assert sub in listener._pending_pre_async
@@ -142,11 +139,6 @@ async def test_online_listener(app, client, mocker):
 
 async def test_offline_publisher(app):
     publisher = events.EventPublisher(app)
-
-    assert publisher.start in app.on_startup
-    assert publisher.close in app.on_cleanup
-
-    # with pytest.raises(ConnectionRefusedError):
     await publisher.publish('exchange', 'key', message=dict(key='val'))
 
 

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -11,18 +11,18 @@ class DummyFeature(features.ServiceFeature):
         super().__init__(app)
         self.name = name
 
-    async def start(app):
+    async def startup(app):
         pass
 
-    async def close(app):
+    async def shutdown(app):
         pass
 
 
 class OtherDummyFeature(features.ServiceFeature):
-    async def start(app):
+    async def startup(app):
         pass
 
-    async def close(app):
+    async def shutdown(app):
         pass
 
 

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -11,18 +11,26 @@ class DummyFeature(features.ServiceFeature):
         super().__init__(app)
         self.name = name
 
-    async def startup(app):
+    async def startup(self, app):
         pass
 
-    async def shutdown(app):
+    async def shutdown(self, app):
         pass
 
 
 class OtherDummyFeature(features.ServiceFeature):
-    async def startup(app):
+    async def startup(self, app):
         pass
 
-    async def shutdown(app):
+    async def shutdown(self, app):
+        pass
+
+
+class DeprecatedFeature(features.ServiceFeature):
+    async def start(self, app):
+        pass
+
+    async def close(self, app):
         pass
 
 
@@ -61,3 +69,7 @@ def test_get(app):
     # slagathor exists, but it's not a DummyFeature
     with pytest.raises(AssertionError):
         features.get(app, DummyFeature, 'slagathor')
+
+
+def test_name_deprecation(app):
+    DeprecatedFeature(app)

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -6,14 +6,23 @@ from unittest.mock import call
 
 import pytest
 
-from brewblox_service import service
+from brewblox_service import service, features
 
 TESTED = service.__name__
+
+
+class DummyFeature(features.ServiceFeature):
+    async def startup(self, app):
+        pass
+
+    async def shutdown(self, app):
+        pass
 
 
 @pytest.fixture
 async def app(app, mocker):
     app.router.add_static(prefix='/static', path='/usr')
+    features.add(app, DummyFeature(app))
     service.furnish(app)
     return app
 


### PR DESCRIPTION
* `start()` / `close()` renamed to `startup()` and `shutdown()` - changes are backwards compatible for now.
* All features are logged during `furnish()`