### PR TITLE
Feature/background task

### DIFF
--- a/brewblox_service/__main__.py
+++ b/brewblox_service/__main__.py
@@ -4,14 +4,15 @@ Entry point for standalone brewblox_service.
 This will create the app, and enable events.
 """
 
-from brewblox_service import events, service
+from brewblox_service import events, scheduler, service
 
 
 def main():
     app = service.create_app(default_name='_service')
 
-    # Event handling is optional
-    # It should be enabled explicitly by service implementations
+    # Event handling is optional, but requires the scheduler
+    # Both should be enabled explicitly by service implementations
+    scheduler.setup(app)
     events.setup(app)
 
     # Add all default endpoints

--- a/brewblox_service/scheduler.py
+++ b/brewblox_service/scheduler.py
@@ -1,0 +1,69 @@
+"""
+Functionality for background tasks.
+"""
+
+import asyncio
+from contextlib import suppress
+from typing import Any, Coroutine, Set
+
+from aiohttp import web
+from brewblox_service import features
+
+CLEANUP_INTERVAL_S = 300
+
+
+def setup(app: web.Application):
+    features.add(app, TaskScheduler(app))
+
+
+def get_scheduler(app: web.Application):
+    return features.get(app, TaskScheduler)
+
+
+async def create_task(app: web.Application,
+                      coro: Coroutine,
+                      loop: asyncio.BaseEventLoop=None
+                      ) -> asyncio.Task:
+    return await get_scheduler(app).create(coro, loop)
+
+
+async def cancel_task(app: web.Application,
+                      task: asyncio.Task,
+                      wait_for: bool=True
+                      ) -> Any:
+    return await get_scheduler(app).cancel(task, wait_for)
+
+
+class TaskScheduler(features.ServiceFeature):
+
+    def __init__(self, app: web.Application):
+        super().__init__(app)
+        self._tasks: Set[asyncio.Task] = set()
+
+    async def startup(self, *_):
+        await self.create(self._cleanup())
+
+    async def shutdown(self, *_):
+        [task.cancel() for task in self._tasks]
+        await asyncio.wait(self._tasks)
+        self._tasks.clear()
+
+    async def _cleanup(self):
+        while True:
+            await asyncio.sleep(CLEANUP_INTERVAL_S)
+            self._tasks = {t for t in self._tasks if not t.done()}
+
+    async def create(self, coro: Coroutine, loop: asyncio.BaseEventLoop=None) -> asyncio.Task:
+        loop = loop or asyncio.get_event_loop()
+        task = loop.create_task(coro)
+        self._tasks.add(task)
+        return task
+
+    async def cancel(self, task: asyncio.Task, wait_for: bool=True) -> Any:
+        task.cancel()
+
+        with suppress(KeyError):
+            self._tasks.remove(task)
+
+        with suppress(Exception):
+            return (await task) if wait_for else None

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -2,7 +2,6 @@
 Tests brewblox_service.features
 """
 
-from asynctest import CoroutineMock
 from brewblox_service import features
 
 import pytest
@@ -26,14 +25,6 @@ class OtherDummyFeature(features.ServiceFeature):
 
     async def shutdown(self, app):
         pass
-
-
-class DeprecatedFeature(features.ServiceFeature):
-
-    def __init__(self, app):
-        self.start = CoroutineMock()
-        self.close = CoroutineMock()
-        super().__init__(app)
 
 
 def test_add(app):
@@ -71,24 +62,3 @@ def test_get(app):
     # slagathor exists, but it's not a DummyFeature
     with pytest.raises(AssertionError):
         features.get(app, DummyFeature, 'slagathor')
-
-
-async def test_name_deprecation(mocker, app, loop):
-    warn_spy = mocker.spy(features.warnings, 'warn')
-
-    debby = DeprecatedFeature(app)
-    assert warn_spy.call_count == 1
-
-    await debby.startup(app)
-    debby.start.assert_called_once_with(app)
-
-    await debby.shutdown(app)
-    debby.close.assert_called_once_with(app)
-
-
-async def test_lazy_feature(app, loop):
-    # Does not implement any meaningful functions
-    lazy = features.ServiceFeature(app)
-
-    await lazy.startup(app)
-    await lazy.shutdown(app)

--- a/test/test_features.py
+++ b/test/test_features.py
@@ -62,3 +62,17 @@ def test_get(app):
     # slagathor exists, but it's not a DummyFeature
     with pytest.raises(AssertionError):
         features.get(app, DummyFeature, 'slagathor')
+
+
+async def test_app_property(app, client):
+    dummy = DummyFeature(None, 'dummy')
+    assert dummy.app is None
+
+    await dummy.startup(app)
+    assert dummy.app == app
+
+    await dummy.shutdown(app)
+    assert dummy.app is None
+
+    with pytest.raises(AttributeError):
+        dummy.app = app

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -38,3 +38,6 @@ async def test_create_cancel(app, client):
 
     # Create and forget
     await scheduler.create_task(app, do(asyncio.Event()))
+
+    # Cancelling None does not croak
+    await scheduler.cancel_task(app, None)

--- a/test/test_scheduler.py
+++ b/test/test_scheduler.py
@@ -1,0 +1,40 @@
+"""
+Tests brewblox_service.scheduler
+"""
+
+
+import asyncio
+
+from brewblox_service import scheduler
+
+import pytest
+
+TESTED = scheduler.__name__
+
+
+@pytest.fixture
+def app(app, mocker):
+    mocker.patch(TESTED + '.CLEANUP_INTERVAL_S', 0.001)
+
+    scheduler.setup(app)
+    return app
+
+
+async def test_create_cancel(app, client):
+
+    async def do(ev):
+        ev.set()
+        return 'ok'
+
+    ev = asyncio.Event()
+    task = await scheduler.create_task(app, do(ev))
+    await ev.wait()
+
+    assert [
+        await scheduler.cancel_task(app, task),
+        await scheduler.cancel_task(app, task),
+        await scheduler.cancel_task(app, task, False),
+    ] == ['ok', 'ok', None]
+
+    # Create and forget
+    await scheduler.create_task(app, do(asyncio.Event()))


### PR DESCRIPTION
Changes:

* `start()`/`close()` functions are no longer supported in `ServiceFeature` (were already deprecated)
* `startup()` / `shutdown()` functions are wrapped to allow for the `ServiceFeature.app` property
  * The property is set when startup is called by anyone, and set to None when `shutdown()` is called
* New module: scheduler. This allows simple creation and cancellation of long-running background tasks.
  * Any tasks created using the scheduler are guaranteed to be cancelled during application shutdown.
  * Clients are free to mix and match the scheduler with other approaches to create, cancel, and await tasks.