### PR TITLE
Bugfix/arm image

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,12 +1,9 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
-
 pprint = "*"
 aiohttp = "*"
 cchardet = "*"
@@ -14,9 +11,7 @@ aiohttp-swagger = "*"
 aiohttp-cors = "*"
 aioamqp = "*"
 
-
 [dev-packages]
-
 pytest-sugar = "*"
 "pytest-flake8" = "*"
 pytest-cov = "*"
@@ -24,8 +19,8 @@ pytest-mock = "*"
 pytest-aiohttp = "*"
 asynctest = "*"
 aioresponses = "*"
-
+"flake8" = "*"
+"autopep8" = "*"
 
 [requires]
-
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f703477fa1c1dd336fbb6a9670b50ff38ca679c58aff300ce2fcd8cdd2025b70"
+            "sha256": "b21a691822fcd3e7416b6cc3aba83a1b54f05e0330d471c70156791dbbed0083"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -115,9 +115,9 @@
         },
         "idna-ssl": {
             "hashes": [
-                "sha256:1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979"
+                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1.0"
         },
         "jinja2": {
             "hashes": [
@@ -159,22 +159,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0c507b7f74b3d2dd4d1322ec8a94794927305ab4cebbe89cc47fe5e81541e6e8",
-                "sha256:16b20e970597e051997d90dc2cddc713a2876c47e3d92d59ee198700c5427736",
-                "sha256:3262c96a1ca437e7e4763e2843746588a965426550f3797a79fca9c6199c431f",
-                "sha256:326420cbb492172dec84b0f65c80942de6cedb5233c413dd824483989c000608",
-                "sha256:4474f8ea030b5127225b8894d626bb66c01cda098d47a2b0d3429b6700af9fd8",
-                "sha256:592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-                "sha256:5ac82e411044fb129bae5cfbeb3ba626acb2af31a8d17d175004b70862a741a7",
-                "sha256:5f84523c076ad14ff5e6c037fe1c89a7f73a3e04cf0377cb4d017014976433f3",
-                "sha256:827dc04b8fa7d07c44de11fabbc888e627fa8293b695e0f99cb544fdfa1bf0d1",
-                "sha256:b4c423ab23291d3945ac61346feeb9a0dc4184999ede5e7c43e1ffb975130ae6",
-                "sha256:bc6bced57f826ca7cb5125a10b23fd0f2fff3b7c4701d64c439a300ce665fff8",
-                "sha256:c01b880ec30b5a6e6aa67b09a2fe3fb30473008c85cd6a67359a1b15ed6d83a4",
-                "sha256:ca233c64c6e40eaa6c66ef97058cdc80e8d0157a443655baa1b2966e812807ca",
-                "sha256:e863072cdf4c72eebf179342c94e6989c67185842d9997960b3e69290b2fa269"
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
-            "version": "==3.12"
+            "version": "==3.13"
         },
         "yarl": {
             "hashes": [
@@ -250,6 +247,13 @@
             ],
             "version": "==18.1.0"
         },
+        "autopep8": {
+            "hashes": [
+                "sha256:2284d4ae2052fedb9f466c09728e30d2e231cfded5ffd7b1a20c34123fdc4ba4"
+            ],
+            "index": "pypi",
+            "version": "==1.3.5"
+        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
@@ -303,6 +307,7 @@
                 "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
                 "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
             ],
+            "index": "pypi",
             "version": "==3.5.0"
         },
         "idna": {
@@ -314,9 +319,9 @@
         },
         "idna-ssl": {
             "hashes": [
-                "sha256:1293f030bc608e9aa9cdee72aa93c1521bbb9c7698068c61c9ada6772162b979"
+                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
             ],
-            "version": "==1.0.1"
+            "version": "==1.1.0"
         },
         "mccabe": {
             "hashes": [
@@ -382,10 +387,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c",
-                "sha256:90898786b3d0b880b47645bae7b51aa9bbf1e9d1e4510c2cfd15dd65c70ea0cd"
+                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
+                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
             ],
-            "version": "==3.6.2"
+            "version": "==3.6.3"
         },
         "pytest-aiohttp": {
             "hashes": [

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberry-pi-python:3.6
+FROM resin/raspberrypi3-python:3.6
 
 EXPOSE 5000
 WORKDIR /app

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,18 @@
 [pytest]
 flake8-max-line-length = 120
+addopts =
+    --cache-clear
+    --cov=brewblox_service
+    --cov-branch
+    --cov-report=term-missing:skip-covered
+    --cov-fail-under=100
+    --no-cov-on-fail
+    --flake8
+
 
 [pep8]
 max-line-length = 120
+
 
 [flake8]
 max-line-length = 120
@@ -16,12 +26,4 @@ envlist = py36
 deps = pipenv
 commands =
     pipenv sync --dev
-    python -m pytest \
-            --cache-clear \
-            --cov=brewblox_service \
-            --cov-branch \
-            --cov-report=term-missing:skip-covered \
-            --cov-fail-under=100 \
-            --no-cov-on-fail \
-            --flake8 \
-            {posargs}
+    pytest {posargs}


### PR DESCRIPTION
Resolves #84 

Makes some tweaks to streamline development inside Pipenv virtual environment:
- flake8 / autopep8 are now dev packages
- pytest arguments are moved to "addopts" in tox.ini. "tox", and "pytest" will now use the same additional cmd arguments.