### PR TITLE
Create wheel files for multistage builds

### DIFF
--- a/docker/amd/Dockerfile
+++ b/docker/amd/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.6
-
 EXPOSE 5000
 WORKDIR /app
 
-COPY ./dist /app/dist
-RUN pip3 install /app/dist/*
-RUN pip3 show brewblox-service
+COPY ./dist /build/dist
+
+RUN pip3 install wheel \
+    && pip3 wheel /build/dist/* --wheel-dir=/wheeley \
+    && pip3 install --no-index --find-links=/wheeley brewblox-service \
+    && pip3 freeze
 
 ENTRYPOINT ["python3", "-m", "brewblox_service"]

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -1,10 +1,12 @@
 FROM resin/raspberrypi3-python:3.6
-
 EXPOSE 5000
 WORKDIR /app
 
-COPY ./dist /app/dist
-RUN pip3 install /app/dist/*
-RUN pip3 show brewblox-service
+COPY ./dist /build/dist
+
+RUN pip3 install wheel \
+    && pip3 wheel /build/dist/* --wheel-dir=/wheeley \
+    && pip3 install --no-index --find-links=/wheeley brewblox-service \
+    && pip3 freeze
 
 ENTRYPOINT ["python3", "-m", "brewblox_service"]


### PR DESCRIPTION
This allows downstream Docker images to add their own wheels, and switch to a smaller base image before installing the previously compiled wheels.