### PR TITLE
Do not attempt to write CORS headers on cancelled request

### DIFF
--- a/brewblox_service/cors_middleware.py
+++ b/brewblox_service/cors_middleware.py
@@ -3,6 +3,8 @@ Cross Origin Resource Sharing (CORS) headers must be present when using multiple
 This middleware automatically returns OPTIONS requests, and appends other requests with the correct headers.
 """
 
+from asyncio import CancelledError
+
 from aiohttp import hdrs, web, web_exceptions
 
 from brewblox_service import brewblox_logger
@@ -32,6 +34,8 @@ async def cors_middleware(request: web.Request, handler: web.RequestHandler) -> 
     else:
         try:
             response = await handler(request)
+        except CancelledError:
+            raise  # Client abandoned request - we're not returning a response anymore
         except web_exceptions.HTTPError as ex:
             response = ex
         except Exception as ex:

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -2,10 +2,12 @@
 Test functions in brewblox_service.service.py
 """
 
+from asyncio import CancelledError
 from unittest.mock import call
 
 import pytest
 from aiohttp import web_exceptions
+from aiohttp.client_exceptions import ServerDisconnectedError
 
 from brewblox_service import features, service
 
@@ -152,6 +154,10 @@ async def test_error_cors(app, client, mocker):
     res = await client.get('/test_app/_service/status')
     assert res.status == 401
     assert 'Access-Control-Allow-Origin' in res.headers
+
+    mocker.patch(TESTED + '.web.json_response').side_effect = CancelledError
+    with pytest.raises(ServerDisconnectedError):
+        await client.get('/test_app/_service/status')
 
 
 def test_run(app, mocker, loop):


### PR DESCRIPTION
Related to brewblox/brewblox-history#51

Errors were caused by attempting to write CORS headers after the client closed the SSE connection.